### PR TITLE
Fix incorrect greedy replacement strategy

### DIFF
--- a/interpreter.php
+++ b/interpreter.php
@@ -54,6 +54,12 @@ $syntax = array(
 
     );
 
+function Comparer($First, $Second){
+	return strlen($Second) - strlen($First);
+}
+
+uksort($syntax, "Comparer"); // sorts syntax array in british order
+
 //loop for the syntax array an replace each british commaned with the php one
 foreach($syntax as $British => $PHP){
   $Code = str_ireplace($British, $PHP, $Code);


### PR DESCRIPTION
Orders syntax replacement strings by length before starting replacements to try replacing longer ones before shorter ones as some are substrings of others.

Input: `is smaller than or equal to`
Output before: `< or equal to`
Output after: `=<`